### PR TITLE
fix: prevent automatic submission when sweetalert timer is dismissed

### DIFF
--- a/auth/delete_account.php
+++ b/auth/delete_account.php
@@ -20,7 +20,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST['username']) && empty(
     
     <?php
     Alert::warning(
-        "Are you sure",
+        "Warning",
         "This cannot be undone.",
         null,
         ["showCancelButton" => true, "submitId" => "delete_account?username=" . $username]

--- a/dashboard/admin/functions/delete_product.php
+++ b/dashboard/admin/functions/delete_product.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['product_id']) && empt
 
     <?php
     Alert::warning(
-        "Are you sure",
+        "Warning",
         "This cannot be undone.",
         null,
         ["showCancelButton" => true, "submitId" => "delete_product?id=" . $product_id]

--- a/dashboard/admin/functions/delete_user.php
+++ b/dashboard/admin/functions/delete_user.php
@@ -19,10 +19,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['user_id']) && isset($
 
     <?php
     Alert::warning(
-        "Are you sure",
+        "Warning",
         "This cannot be undone.",
         null,
-        ["timer" => null, "showCancelButton" => true, "submitId" => "delete_user_account?id=" . $userid]
+        ["showCancelButton" => true, "submitId" => "delete_user_account?id=" . $userid]
     );
     exit();
 }

--- a/src/Utils/Alert.php
+++ b/src/Utils/Alert.php
@@ -26,10 +26,12 @@ class Alert
 
         echo <<<JS
         <script>
-        setTimeout(function() {
+        setTimeout(function() 
+        {
             const config = {$jscode};
             Swal.fire(config).then((result)=>{
-                if(result.isConfirmed||result.dismiss === Swal.DismissReason.timer){
+                if(result.isConfirmed)
+                {
                     if(config.submitId){
                         document.getElementById(config.submitId)?.submit();
                     }
@@ -37,7 +39,17 @@ class Alert
                         window.location.href = config.redirect;
                     }
                 }
-                else{
+                else if(result.dismiss === Swal.DismissReason.timer)
+                {
+                    if (config.redirect && !config.submitId){
+                        window.location.href = config.redirect;
+                    }
+                    else{
+                        window.history.back();
+                    }
+                }
+                else if(result.dismiss === Swal.DismissReason.cancel)
+                {
                     if(config.cancelRedirect){
                         window.location.href = config.cancelRedirect;
                     }
@@ -77,6 +89,14 @@ class Alert
             $extra['timer'] = 2000;
         }
         self::alert("success",$title,$text, $redirect, $extra);
+    }
+
+    public static function question($title, $text, $redirect = null, $extra = [])
+    {
+        if(!isset($extra['timer'])){
+            $extra['timer'] = 5000;
+        }
+        self::alert("question", $title, $text, $redirect, $extra);
     }
 
     public static function error($title, $text, $redirect = null, $extra = [])


### PR DESCRIPTION
## Changes
- Added a check `!config.submitId` within the timer dismissal branch.
- Ensured that `submitId` is only triggered if `result.isConfirmed` is true.
- Implemented `window.history.back()` as a fallback to prevent blank screens when a timer expires without a defined redirect.

## Why this is necessary
To ensure application security and improve UX by preventing accidental destructive actions when a user is inactive.

## Related Issue
Fixes #3