### PR TITLE
fix(logging): replace stale write_log calls after Logger migration

### DIFF
--- a/core/countries.php
+++ b/core/countries.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/init.php';
 
-use App\Utils\Helper;
+use App\Utils\Logger;
 
 $countries = file_get_contents(__DIR__ . '/../data/countries.json');
 $data = json_decode($countries, true);
@@ -11,7 +11,7 @@ $countries = "INSERT INTO countries (id,name,iso2,created_at,calling_codes)
 VALUES(?,?,?,?,?)";
 $stmt = $conn->prepare($countries);
 if(!$stmt){
-    Helper::write_log("Prepare failed: " . $conn->error, 'ERROR');
+    Logger::error("Prepare failed: " . $conn->error);
 }
 
 $id = $name = $iso2 = $created_at = $calling_codes = "";
@@ -26,7 +26,7 @@ foreach ($data as $country)
     $iso2 = $country["alpha2Code"];
     $calling_codes = '+' . $country["callingCodes"][0];
     if(!$stmt->execute()){
-        Helper::write_log("Execute failed:" . $stmt->error, 'ERROR');
+        Logger::error("Execute failed:" . $stmt->error);
     }
 
 }

--- a/dashboard/admin/functions/delete_product.php
+++ b/dashboard/admin/functions/delete_product.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../../../core/init.php';
 
 use App\Security\Csrf;
 use App\Utils\Alert;
-use App\Utils\Helper;
+use App\Utils\Logger;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['product_id']) && empty($_POST['confirm'])) {
     $product_id = $_POST['product_id'];
@@ -36,7 +36,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['confirm']) && $_POST[
     if ($stmt) {
         $stmt->bind_param("i", $product_id);
         if (!$stmt->execute()) {
-            Helper::write_log("Delete failed: " . $stmt->error, 'ERROR');
+            Logger::error("Delete failed: " . $stmt->error);
         }
 
         if ($stmt->affected_rows > 0) {

--- a/dashboard/admin/functions/edit_product.php
+++ b/dashboard/admin/functions/edit_product.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../../../core/init.php';
 
 use App\Security\Csrf;
 use App\Utils\Alert;
-use App\Utils\Helper;
+use App\Utils\Logger;
 
 $product_id = null;
 $product_names = $description = $price = $original_price = $stock = $brand = $images = "";
@@ -38,7 +38,7 @@ if ($_SERVER["REQUEST_METHOD"] == "GET" && isset($_GET['product_id'])) {
         }
     } 
     else {
-        Helper::write_log("Prepare failed: " . $conn->error, 'ERROR');
+        Logger::error("Prepare failed: " . $conn->error);
     }
 }
 

--- a/dashboard/admin/functions/edit_user.php
+++ b/dashboard/admin/functions/edit_user.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../../../core/init.php';
 
 use App\Security\Csrf;
 use App\Utils\Alert;
-use App\Utils\Helper;
+use App\Utils\Logger;
 
 if ($_SERVER["REQUEST_METHOD"] == "GET" && isset($_GET['user_id'])) {
 
@@ -31,7 +31,7 @@ if ($_SERVER["REQUEST_METHOD"] == "GET" && isset($_GET['user_id'])) {
         }
     } 
     else {
-        Helper::write_log("Prepare failed: " . $conn->error, 'ERROR');
+        Logger::error("Prepare failed: " . $conn->error);
     }
 }
 

--- a/dashboard/admin/functions/upload_products.php
+++ b/dashboard/admin/functions/upload_products.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../../../core/init.php';
 
 use App\Security\Csrf;
 use App\Utils\Alert;
-use App\Utils\Helper;
+use App\Utils\Logger;
 
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
 
@@ -69,7 +69,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
             $stmt->close();
         } 
         else {
-            Helper::write_log("SQL prepare failed: " . $conn->error, 'ERROR');
+            Logger::error("SQL prepare failed: " . $conn->error);
         }
     }
 }

--- a/dashboard/admin/index.php
+++ b/dashboard/admin/index.php
@@ -3,13 +3,13 @@
 require_once __DIR__ . '/../../core/init.php';
 
 use App\Security\Csrf;
-use App\Utils\Helper;
+use App\Utils\Logger;
 
 $sql = 'SELECT product_id, product_name, brand, stock, original_price, description, price, star, product_images FROM products';
 $result = $conn->query($sql);
 
 if (!$result) {
-    Helper::write_log("Prepare failed: " . $conn->error, 'ERROR');
+    Logger::error("Prepare failed: " . $conn->error);
 }
 ?>
 

--- a/dashboard/admin/views/user_accounts.php
+++ b/dashboard/admin/views/user_accounts.php
@@ -3,14 +3,14 @@
 require_once __DIR__ . '/../../../core/init.php';
 
 use App\Security\Csrf;
-use App\Utils\Helper;
+use App\Utils\Logger;
 
 $user_account = "SELECT user_id ,username,email,token,token_expiry 
 FROM user_accounts";
 $result = $conn->query($user_account);
 
 if (!$result) {
-    Helper::write_log("Prepare failed: " . $conn->error, 'ERROR');
+    Logger::error("Prepare failed: " . $conn->error);
 }
 ?>
 

--- a/index.php
+++ b/index.php
@@ -2,15 +2,15 @@
 
 require_once __DIR__ . '/core/init.php';
 
-use App\Utils\Helper;
 use App\Utils\Lang;
+use App\Utils\Logger;
 
 $sql = 'SELECT product_id, product_name, original_price, 
 description, brand,price, star, product_images FROM products';
 $result = $conn->query($sql);
 
 if (!$result) {
-  Helper::write_log("Prepare failed: " . $conn->error,'ERROR');
+    Logger::error("Prepare failed: " . $conn->error);
 }
 ?>
 

--- a/src/Services/CartService.php
+++ b/src/Services/CartService.php
@@ -3,7 +3,7 @@
 namespace App\Services;
 
 use mysqli;
-use App\Utils\Helper;
+use App\Utils\Logger;
 
 class CartService
 {
@@ -89,13 +89,13 @@ class CartService
         $update = "UPDATE products SET stock = stock - ? WHERE product_id = ? AND stock >= ?";
         $stmt = $this->conn->prepare($update);
         if (!$stmt) {
-            Helper::write_log("Prepare failed:" . $this->conn->error, 'ERROR');
+            Logger::error("Prepare failed:" . $this->conn->error);
             return;
         }
         $stmt->bind_param('iii', $purchase_qty, $product_id, $purchase_qty);
         $stmt->execute();
         if (!$stmt) {
-            Helper::write_log("Execute failed:" . $stmt->error, 'ERROR');
+            Logger::error("Execute failed:" . $stmt->error);
             return;
         }
     }

--- a/views/cart.php
+++ b/views/cart.php
@@ -4,8 +4,8 @@ require_once __DIR__ . '/../core/init.php';
 
 use App\Security\Csrf;
 use App\Services\CartService;
-use App\Utils\Helper;
 use App\Utils\Lang;
+use App\Utils\Logger;
 
 $CartService = new CartService($conn);
 
@@ -106,7 +106,7 @@ if (isset($_POST['delete_quantity'])) {
             <?php
                 } 
                 else {
-                    Helper::write_log("Prepare failed: " . $conn->error, 'ERROR');
+                    Logger::error("Prepare failed: " . $conn->error);
                 }
             } else {
                 echo "<p style='user-select: none;' class='fs-1 text-center  text-danger'>" . Lang::__('Your cart is empty') . "</p>";

--- a/views/checkout.php
+++ b/views/checkout.php
@@ -7,6 +7,7 @@ use App\Services\CartService;
 use App\Services\Mail;
 use App\Utils\Helper;
 use App\Utils\Lang;
+use App\Utils\Logger;
 
 $CartService = new CartService($conn);
 
@@ -59,7 +60,7 @@ if (isset($_POST['checkout'])) {
 
             $stmt = $conn->prepare($order_details);
             if (!$stmt) {
-                Helper::write_log("Prepare failed: " . $conn->error, 'ERROR');
+                Logger::error("Prepare failed: " . $conn->error);
             }
 
             $total_price = 0;
@@ -92,7 +93,7 @@ if (isset($_POST['checkout'])) {
         # code...
     } 
     else {
-        Helper::write_log("Error: " . $conn->error, 'ERROR');
+        Logger::error("Error: " . $conn->error);
     }
 
     if (isset($_SESSION['Swalfire'])) {

--- a/views/order_history.php
+++ b/views/order_history.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../core/init.php';
 
 use App\Utils\Helper;
 use App\Utils\Lang;
+use App\Utils\Logger;
 
 $user_id = $_SESSION['user_id'];
 if (!$user_id) {
@@ -35,7 +36,7 @@ oi.orders_created_at DESC
 
 $stmt = $conn->prepare($sql);
 if (!$stmt) {
-    Helper::write_log("SQL prepare failed: " . $conn->error,'ERROR');
+    Logger::error("SQL prepare failed: " . $conn->error);
 }
 $stmt->bind_param("s", $user_id);
 $stmt->execute();


### PR DESCRIPTION
## Summary

Complete the Logger migration by replacing remaining `Helper::write_log()` calls with `Logger::error()`.

After `Helper::write_log()` was removed and logging moved to `Logger`, several files still referenced the old method. Those error paths would throw a fatal error at runtime when triggered.