### PR TITLE
fix(views): run redirects before header output

### DIFF
--- a/views/cart.php
+++ b/views/cart.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__ . '/../core/init.php';
+require_once __DIR__ . '/../views/includes/header.php';
 
 use App\Security\Csrf;
 use App\Services\CartService;
@@ -26,8 +27,6 @@ if (isset($_POST['delete_quantity'])) {
     $CartService->delete_cart_qty($_POST['product_id'], $_POST['quantity']);
 }
 ?>
-
-<?php include __DIR__ . ('/../views/includes/header.php'); ?>
 
 <title>Cart</title>
 

--- a/views/checkout.php
+++ b/views/checkout.php
@@ -1,5 +1,7 @@
 <?php
+
 require_once __DIR__ . '/../core/init.php';
+require_once __DIR__ . '/../views/includes/header.php';
 
 use App\Security\Csrf;
 use App\Utils\Alert;
@@ -103,8 +105,6 @@ if (isset($_POST['checkout'])) {
 }
 
 ?>
-
-<?php include __DIR__ . ('/../views/includes/header.php'); ?>
 
 <title>Checkout form</title>
 

--- a/views/forgot_password.php
+++ b/views/forgot_password.php
@@ -18,7 +18,7 @@ if (isset($_SESSION['Swalfire'])) {
 
 ?>
 
-<?php require_once __DIR__ . '../../views/includes/header.php'; ?>
+<?php require_once __DIR__ . '/../views/includes/header.php'; ?>
 
 <title>Forgot Password</title>
 

--- a/views/includes/header.php
+++ b/views/includes/header.php
@@ -1,3 +1,5 @@
+<?php require_once __DIR__ . '/../../auth/auth.php'; ?>
+
 <!DOCTYPE html>
 <html lang="en">
 
@@ -14,5 +16,4 @@
 </head>
 
 <body>
-    <?php require_once __DIR__ . '/../../auth/auth.php'; ?>
     <?php require_once __DIR__ . '/navbar.php'; ?>

--- a/views/reset_password.php
+++ b/views/reset_password.php
@@ -13,12 +13,12 @@ if (isset($_SESSION['Swalfire'])) {
 
 ?>
 
-<?php require_once __DIR__ . '../../views/includes/header.php'; ?>
+<?php require_once __DIR__ . '/../views/includes/header.php'; ?>
 
 <title>Reset Password</title>
 
 <section class="py-3 py-md-5 py-xl-8 was-validated">
-    <form method="POST" action="<?= WEBSITE_URL . "auth/reset_password.php?token=".urldecode($_GET['token'] ?? ''); ?>">
+    <form method="POST" action="<?= WEBSITE_URL . "auth/reset_password.php?token=" . urldecode($_GET['token'] ?? ''); ?>">
         <?= Csrf::csrf_field() ?>
         <div class="container">
 

--- a/views/view_product.php
+++ b/views/view_product.php
@@ -6,7 +6,9 @@ use App\Security\Csrf;
 use App\Utils\Helper;
 use App\Utils\Lang;
 
-if (isset($_GET['id'])) {
+if (!isset($_GET['id'])) { 
+    Helper::redirect_to(WEBSITE_URL . "views/404.php");
+}
     $product_id = $_GET['id'];
 
     $query = "SELECT * FROM products WHERE product_id = ?";
@@ -15,11 +17,14 @@ if (isset($_GET['id'])) {
     $stmt->execute();
     $result = $stmt->get_result();
 
-    if ($result->num_rows > 0) {
-        $row = $result->fetch_assoc();
-?>
+    if ($result->num_rows === 0) {
+        Helper::redirect_to(WEBSITE_URL . "views/404.php");
+    }
+    $row = $result->fetch_assoc();
+    $stmt->close();
 
-        <?php include __DIR__ . ('/../views/includes/header.php'); ?>
+    require_once __DIR__ . '/../views/includes/header.php';
+?>
 
         <title>View Product</title>
 
@@ -107,18 +112,6 @@ if (isset($_GET['id'])) {
 
         <!-- Footer -->
         <?php include __DIR__ . ('/../views/includes/footer.php'); ?>
-<?php
-    } else {
-        Helper::redirect_to(WEBSITE_URL . "views/404.php");
-    }
-    $stmt->close();
-} else {
-    Helper::redirect_to(WEBSITE_URL . "views/404.php");
-}
-
-$conn->close();
-?>
-
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

Fix "headers already sent" warnings by ensuring auth checks and 404 redirects run before any HTML output.

## Changes

### Header & auth
- Move `auth.php` to the top of `header.php`, before `<!DOCTYPE html>`, so unauthenticated redirects happen before HTML is sent

### View pages
- **`view_product.php`**: Validate product ID and query result first; redirect to 404 before including header
- **`cart.php`**, **`checkout.php`**: Include header after `init.php` and POST handling, before page content output

### Auth views
- **`forgot_password.php`**, **`reset_password.php`**: Fix broken header include path (`__DIR__ . '../../views/...'` → `__DIR__ . '/../views/includes/header.php'`)