### PR TITLE
fix(views): guard session access and defer header until after POST ha…

### DIFF
--- a/dashboard/user/views/profile.php
+++ b/dashboard/user/views/profile.php
@@ -7,7 +7,9 @@ use App\Utils\Alert;
 use App\Utils\Helper;
 use App\Utils\Lang;
 
-$user_id = $_SESSION['user_id'];
+$row = [];
+
+$user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
     Helper::redirect_to(WEBSITE_URL . "views/login.php");
 }
@@ -17,9 +19,7 @@ if (isset($_SESSION['Swalfire'])) {
     unset($_SESSION['Swalfire']);
 }
 
-if (isset($_SESSION['user_id'])) {
-    $user_id = $_SESSION['user_id'];
-    $profiles = "SELECT 
+$profiles = "SELECT 
     up.first_name AS f_name, 
     up.last_name AS l_name,
     up.calling_code AS call_code,
@@ -33,13 +33,12 @@ if (isset($_SESSION['user_id'])) {
     FROM user_profiles up
     JOIN user_accounts ua ON up.user_id = ua.user_id
     WHERE up.user_id = ?";
-
+    
     $stmt = $conn->prepare($profiles);
     $stmt->bind_param("s", $user_id);
     $stmt->execute();
     $result = $stmt->get_result();
-    $row = $result->fetch_assoc();
-}
+    $row = $result->fetch_assoc() ?? [];
 
 ?>
 

--- a/views/cart.php
+++ b/views/cart.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once __DIR__ . '/../core/init.php';
-require_once __DIR__ . '/../views/includes/header.php';
 
 use App\Security\Csrf;
 use App\Services\CartService;
@@ -26,6 +25,8 @@ if (isset($_POST['remove_from_cart'])) {
 if (isset($_POST['delete_quantity'])) {
     $CartService->delete_cart_qty($_POST['product_id'], $_POST['quantity']);
 }
+
+require_once __DIR__ . '/../views/includes/header.php';
 ?>
 
 <title>Cart</title>

--- a/views/checkout.php
+++ b/views/checkout.php
@@ -1,7 +1,6 @@
 <?php
 
 require_once __DIR__ . '/../core/init.php';
-require_once __DIR__ . '/../views/includes/header.php';
 
 use App\Security\Csrf;
 use App\Utils\Alert;
@@ -15,6 +14,8 @@ $CartService = new CartService($conn);
 
 //all country list
 $countries = Helper::all_countries($conn);
+
+$row = [];
 
 if (isset($_POST['remove_from_cart'])) {
 
@@ -104,6 +105,7 @@ if (isset($_POST['checkout'])) {
     }
 }
 
+require_once __DIR__ . '/../views/includes/header.php';
 ?>
 
 <title>Checkout form</title>

--- a/views/order_history.php
+++ b/views/order_history.php
@@ -6,12 +6,11 @@ use App\Utils\Helper;
 use App\Utils\Lang;
 use App\Utils\Logger;
 
-$user_id = $_SESSION['user_id'];
+$user_id = $_SESSION['user_id'] ?? null;
 if (!$user_id) {
-    Helper::redirect_to("login.php");
+    Helper::redirect_to(WEBSITE_URL . "views/login.php");
 }
 
-$user_id = $_SESSION['user_id'];
 $sql = "SELECT 
 pd.product_name,
 pd.product_images,
@@ -63,9 +62,9 @@ while ($row = $result->fetch_assoc()) {
         'cat_name' => $row['cat_name']
     ];
 }
-?>
 
-<?php include __DIR__ . '/../views/includes/header.php'; ?>
+require_once __DIR__ . '/../views/includes/header.php';
+?>
 
 <body class="bg-white">
 


### PR DESCRIPTION
## Summary

Follow-up to PR #12. Fix remaining header/redirect issues where session access or POST handling could run after HTML output had started.

## Changes

### Session guards
- Use `?? null` when reading `$_SESSION['user_id']` in `order_history.php` and `profile.php`
- Redirect unauthenticated users with full `WEBSITE_URL` paths before including header
- Remove redundant session checks and duplicate `$user_id` assignments in `profile.php` and `order_history.php`

### Header include order
- Move `header.php` include to after POST/CSRF handlers in `cart.php` and `checkout.php`
- Keep `order_history.php` DB logic before header output

### Defensive defaults
- Initialize `$row` in `profile.php` and `checkout.php` to avoid undefined variable issues